### PR TITLE
Use built-in exception groups in Python 3.11+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     keywords='websocket client server trio',
     packages=find_packages(exclude=['docs', 'examples', 'tests']),
     install_requires=[
-        'exceptiongroup',
+        'exceptiongroup; python_version<"3.11"',
         'trio>=0.11',
         'wsproto>=0.14',
     ],

--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -13,7 +13,6 @@ from typing import List, Optional, Union
 
 import trio
 import trio.abc
-from exceptiongroup import BaseExceptionGroup
 from wsproto import ConnectionType, WSConnection
 from wsproto.connection import ConnectionState
 import wsproto.frame_protocol as wsframeproto
@@ -29,6 +28,9 @@ from wsproto.events import (
     TextMessage,
 )
 import wsproto.utilities
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
 
 _TRIO_MULTI_ERROR = tuple(map(int, trio.__version__.split('.')[:2])) < (0, 22)
 


### PR DESCRIPTION
Python 3.12+ features built-in exception group support, and does not require third-party `exceptiongroup` package.  Make the import and the dependency conditional to older Python versions.