### PR TITLE
add py3.11+3.12 and pypy3.9+3.10 to CI, conditionally require exceptiongroup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,15 @@ on:
       - master
   pull_request:
 
+# pylint crashes on 3.12 due to https://github.com/pylint-dev/astroid/issues/2201
+# see https://github.com/pylint-dev/pylint/issues/8782
 jobs:
   build_and_test_pinned:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -52,7 +54,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['pypy-3.7']
+        python-version: ['pypy-3.9','pypy-3.10']
 
     steps:
       - uses: actions/checkout@v3
@@ -70,7 +72,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.11']
+        python-version: ['3.12']
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.12']
+        python-version: ['3.12-dev']
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ click==8.1.3
     # via pip-tools
 coverage[toml]==7.2.1
     # via pytest-cov
-cryptography==39.0.2
+cryptography==41.0.4
     # via trustme
 exceptiongroup==1.1.0
     # via

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
@@ -40,7 +41,7 @@ setup(
     keywords='websocket client server trio',
     packages=find_packages(exclude=['docs', 'examples', 'tests']),
     install_requires=[
-        'exceptiongroup',
+        'exceptiongroup; python_version<"3.11"',
         'trio>=0.11',
         'wsproto>=0.14',
     ],

--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -13,7 +13,6 @@ from typing import List, Optional, Union
 
 import trio
 import trio.abc
-from exceptiongroup import BaseExceptionGroup
 from wsproto import ConnectionType, WSConnection
 from wsproto.connection import ConnectionState
 import wsproto.frame_protocol as wsframeproto
@@ -29,6 +28,10 @@ from wsproto.events import (
     TextMessage,
 )
 import wsproto.utilities
+
+if sys.version_info < (3, 11):  # pragma: no cover
+    # pylint doesn't care about the version_info check, so need to ignore the warning
+    from exceptiongroup import BaseExceptionGroup  # pylint: disable=redefined-builtin
 
 _TRIO_MULTI_ERROR = tuple(map(int, trio.__version__.split('.')[:2])) < (0, 22)
 
@@ -65,7 +68,7 @@ class _preserve_current_exception:
         if value is None or not self._armed:
             return False
 
-        if _TRIO_MULTI_ERROR:
+        if _TRIO_MULTI_ERROR:  # pragma: no cover
             filtered_exception = trio.MultiError.filter(_ignore_cancel, value)  # pylint: disable=no-member
         elif isinstance(value, BaseExceptionGroup):
             filtered_exception = value.subgroup(lambda exc: not isinstance(exc, trio.Cancelled))


### PR DESCRIPTION
I wrote this ... and then I saw the discussion in #180 
So this is kind of a duplicate of that, except I also updated CI to test it, and general compatibility with 3.11/3.12, as well as pypy3.9 and pypy3.10.

I don't think there's any reason *not* to update so as not to require `exceptiongroup` on py3.11+, [and it mirrors python-trio/trio](https://github.com/python-trio/trio/blob/master/setup.py#L96).

pypy3.9 and pypy3.10 are the [currently supported versions of python](https://doc.pypy.org/en/latest/release-v7.3.12.html)

As mentioned in the comment in `ci.yml`, running `pylint` on 3.12 crashes, see https://github.com/pylint-dev/pylint/issues/8782