### PR TITLE
Don't explicitly pass a default (small) receive size, let trio choose.

### DIFF
--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -38,7 +38,6 @@ _TRIO_MULTI_ERROR = tuple(map(int, trio.__version__.split('.')[:2])) < (0, 22)
 CONN_TIMEOUT = 60 # default connect & disconnect timeout, in seconds
 MESSAGE_QUEUE_SIZE = 1
 MAX_MESSAGE_SIZE = 2 ** 20 # 1 MiB
-RECEIVE_BYTES = 4 * 2 ** 10 # 4 KiB
 logger = logging.getLogger('trio-websocket')
 
 
@@ -1232,7 +1231,7 @@ class WebSocketConnection(trio.abc.AsyncResource):
 
                 # Get network data.
                 try:
-                    data = await self._stream.receive_some(RECEIVE_BYTES)
+                    data = await self._stream.receive_some()
                 except (trio.BrokenResourceError, trio.ClosedResourceError):
                     await self._abort_web_socket()
                     break


### PR DESCRIPTION
The default size of 4 KiB is very small, and caused a lot of loops receiving buffers, that were clearly visible in benchmarks.

Also, it's not needed: ` Optional; if omitted, then the stream object is free to pick a reasonable default.`
So maybe let's not invent a redundant default here?

By passing None, it currently means we end up with 64 KiB instead, which sounds more appropriate: https://github.com/python-trio/trio/blob/master/src/trio/_highlevel_socket.py#L21-L25
And it can be hoped that later this will automagically become more intelligent if they implement the TODO.