### PR TITLE
fix loss of context/cause on exceptions raised inside open_websocket

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -496,7 +496,7 @@ async def test_open_websocket_internal_exc(nursery, monkeypatch, autojump_clock)
 
     assert exc_info.value is user_error
     e_context = exc_info.value.__context__
-    assert isinstance(e_context, BaseExceptionGroup)
+    assert isinstance(e_context, BaseExceptionGroup)  # pylint: disable=possibly-used-before-assignment
     assert internal_error in e_context.exceptions
     assert user_error_context in e_context.exceptions
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -596,7 +596,7 @@ async def test_user_exception_cause(nursery) -> None:
         assert e.__cause__ is e_cause
 
         # the nursery-internal group is injected as context
-        assert isinstance(e.__context__, ExceptionGroup)
+        assert isinstance(e.__context__, _TRIO_EXC_GROUP_TYPE)
         assert e.__context__.exceptions[0] is e_primary
         assert e.__context__.exceptions[0].__context__ is e_context
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -31,6 +31,7 @@ circumstances
 '''
 from __future__ import annotations
 
+import copy
 from functools import partial, wraps
 import re
 import ssl
@@ -1205,3 +1206,16 @@ async def test_remote_close_rude():
     async with trio.open_nursery() as nursery:
         nursery.start_soon(server)
         nursery.start_soon(client)
+
+
+def test_copy_exceptions():
+    # test that exceptions are copy- and pickleable
+    copy.copy(HandshakeError())
+    copy.copy(ConnectionTimeout())
+    copy.copy(DisconnectionTimeout())
+    assert copy.copy(ConnectionClosed("foo")).reason == "foo"
+
+    rej_copy = copy.copy(ConnectionRejected(404, (("a", "b"),), b"c"))
+    assert rej_copy.status_code == 404
+    assert rej_copy.headers == (("a", "b"),)
+    assert rej_copy.body == b"c"

--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -92,16 +92,6 @@ class _preserve_current_exception:
             filtered_exception = _ignore_cancel(value)
         return filtered_exception is None
 
-def copy_exc(e: BaseException) -> BaseException:
-    """Copy an exception.
-
-    `copy.copy` fails on `trio.Cancelled`, and on exceptions with a custom `__init__`
-    that calls `super().__init__()`. It may be the case that this also fails on something.
-    """
-    cls = type(e)
-    result = cls.__new__(cls)
-    result.__dict__ = copy.copy(e.__dict__)
-    return result
 
 @asynccontextmanager
 async def open_websocket(

--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -608,7 +608,7 @@ class ConnectionClosed(Exception):
         :param reason:
         :type reason: CloseReason
         '''
-        super().__init__()
+        super().__init__(reason)
         self.reason = reason
 
     def __repr__(self):
@@ -628,7 +628,7 @@ class ConnectionRejected(HandshakeError):
         :param reason:
         :type reason: CloseReason
         '''
-        super().__init__()
+        super().__init__(status_code, headers, body)
         #: a 3 digit HTTP status code
         self.status_code = status_code
         #: a tuple of 2-tuples containing header key/value pairs


### PR DESCRIPTION
fixes #191 

I'm not 100% sure that `copy_exc` is 100% robust (given that everything seems ever so fickle with copying exceptions), so it may be a good idea to wrap it in a `try: except` that gives up on copying if anything fails.