### PR TITLE
Use correct port for wss URLs when ssl_context is None

### DIFF
--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -518,7 +518,7 @@ def _url_to_host(
     if parts.port is not None:
         port = parts.port
     else:
-        port = 443 if ssl_context else 80
+        port = 443 if return_ssl_context else 80
     path_qs = parts.path
     # RFC 7230, Section 5.3.1:
     # If the target URI's path component is empty, the client MUST


### PR DESCRIPTION
Prior to https://github.com/python-trio/trio-websocket/commit/49b93c1b5a7977b5e37b6b16650b6a41c2064f98, `_url_to_host()` modified `ssl_context` according to whether the URL contained `ws` or `wss`. That commit introduced `return_ssl_context` because the return value has a different type set (`ssl.SSLContext | bool`) than the passed in argument (`ssl.SSLContext | None`). But the determination of which port number to use was still based on `ssl_context`, which would result in port 80 being used in the case where the user passed in a `wss://` URL without an SSLContext. Checking `return_ssl_context` instead results in the correct behavior. 